### PR TITLE
Fixes matrix size comparison bug

### DIFF
--- a/qbMatrix.h
+++ b/qbMatrix.h
@@ -606,7 +606,7 @@ template <class T>
 bool qbMatrix2<T>::operator== (const qbMatrix2<T>& rhs)
 {
 	// Check if the matricies are the same size, if not return false.
-	if ((this->m_nRows != rhs.m_nRows) && (this->m_nCols != rhs.m_nCols))
+	if ((this->m_nRows != rhs.m_nRows) || (this->m_nCols != rhs.m_nCols))
 		return false;
 		
 	// Check if the elements are equal.


### PR DESCRIPTION
This bug fix addresses an issue in the matrix comparison function. In certain cases, when matrices of different sizes but with similar data were compared, the function would incorrectly return "true". This has now been corrected and the function will accurately determine if the matrices are of different sizes, even if the data is similar.